### PR TITLE
Exposing port makes it more friendly to Traefik

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,5 @@ RUN chmod a+rx /startup.sh && \
 	chown -R nobody:nobody /var/lib/php/session
 
 USER nobody
+EXPOSE 8000
 CMD [ "/startup.sh" ]


### PR DESCRIPTION
Also allows Portainer to auto-map ports and is better descriptive of the image.